### PR TITLE
Add main function comment to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 # This is the Coder Makefile. The build directory for most tasks is `build/`.
+# 
+# Main function: Default target is `build-fat` which builds a full binary with UI
+# for each supported OS/architecture combination. This provides the complete
+# Coder binary for provisioning development environments.
 #
 # These are the targets you're probably looking for:
-# - clean
+# - clean 
 # - build-fat: builds all "fat" binaries for all architectures
 # - build-slim: builds all "slim" binaries (no frontend or slim binaries
 #   embedded) for all architectures


### PR DESCRIPTION
## Summary
- Add a comment describing the main function of the Makefile
- Clarify that the default target is 'build-fat'
- Explain that this target builds a full binary with UI for each supported OS/architecture

## Test plan
- Review the added comment in the Makefile
- Ensure the comment accurately describes the Makefile's main function
- Verify that no functional changes were made to the Makefile

🤖 Generated with [Claude Code](https://claude.ai/code)