### PR TITLE
Display environment context in CLI error messages

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -40,6 +40,7 @@ import (
 	"github.com/coder/coder/v2/cli/telemetry"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
+	"github.com/coder/coder/v2/cli/env"
 )
 
 var (
@@ -72,7 +73,9 @@ const (
 	varDisableDirect           = "disable-direct-connections"
 	varDisableNetworkTelemetry = "disable-network-telemetry"
 
-	notLoggedInMessage = "You are not logged in. Try logging in using 'coder login <url>'."
+	// notLoggedInMessage is used when the user is not logged in.
+	// This function returns the message with environment-specific context.
+	notLoggedInMessage = "You are not logged in."
 
 	envNoVersionCheck   = "CODER_NO_VERSION_WARNING"
 	envNoFeatureWarning = "CODER_NO_FEATURE_WARNING"
@@ -534,7 +537,7 @@ func (r *RootCmd) InitClient(client *codersdk.Client) serpent.MiddlewareFunc {
 				rawURL, err := conf.URL().Read()
 				// If the configuration files are absent, the user is logged out
 				if os.IsNotExist(err) {
-					return xerrors.New(notLoggedInMessage)
+					return xerrors.Errorf("%s. %s", notLoggedInMessage, FormatLoginCommand(env.CODER_URL, env.CODER_SSH_CONFIG_BINARY_PATH))
 				}
 				if err != nil {
 					return err
@@ -1396,4 +1399,18 @@ func fullYamlName(opt serpent.Option) string {
 	}
 	_, _ = full.WriteString(opt.YAML)
 	return full.String()
+}
+
+// FormatLoginCommand returns a formatted login command suggestion based on the environment variables.
+func FormatLoginCommand(coderURL, coderBinary string) string {
+	var cmd strings.Builder
+	cmd.WriteString("Try logging in using: ")
+
+	if coderBinary != "" {
+		cmd.WriteString(fmt.Sprintf("'%s login %s'", coderBinary, coderURL))
+	} else {
+		cmd.WriteString(fmt.Sprintf("'coder login %s'", coderURL))
+	}
+
+	return cmd.String()
 }

--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -80,6 +80,27 @@ const (
 	internalErrorMessage  = "An internal error occurred. Please try again or contact the system administrator."
 )
 
+// FormatLoginCommand returns a formatted login command suggestion based on the request context.
+// It includes environment variables like CODER_URL and other relevant configuration.
+func FormatLoginCommand(r *http.Request) string {
+	var cmd strings.Builder
+	cmd.WriteString("Try logging in using: ")
+
+	// If CODER_URL environment variable is set, use that
+	coderURL := os.Getenv("CODER_URL")
+	if coderURL == "" {
+		// Otherwise use the request URL as a fallback
+		coderURL = fmt.Sprintf("%s://%s", r.URL.Scheme, r.URL.Host)
+	}
+
+	if coderBinary := os.Getenv("CODER_SSH_CONFIG_BINARY_PATH"); coderBinary != "" {
+		cmd.WriteString(fmt.Sprintf("'%s login %s'", coderBinary, coderURL))
+	} else {
+		cmd.WriteString(fmt.Sprintf("'coder login %s'", coderURL))
+	}
+	return cmd.String()
+}
+
 type ExtractAPIKeyConfig struct {
 	DB                          database.Store
 	ActivateDormantUser         func(ctx context.Context, u database.User) (database.User, error)
@@ -149,7 +170,7 @@ func APIKeyFromRequest(ctx context.Context, db database.Store, sessionTokenFunc 
 	token := tokenFunc(r)
 	if token == "" {
 		return nil, codersdk.Response{
-			Message: SignedOutErrorMessage,
+			Message: fmt.Sprintf("%s", FormatLoginCommand(r)),
 			Detail:  fmt.Sprintf("Cookie %q or query parameter must be provided.", codersdk.SessionTokenCookie),
 		}, false
 	}
@@ -157,7 +178,7 @@ func APIKeyFromRequest(ctx context.Context, db database.Store, sessionTokenFunc 
 	keyID, keySecret, err := SplitAPIToken(token)
 	if err != nil {
 		return nil, codersdk.Response{
-			Message: SignedOutErrorMessage,
+			Message: fmt.Sprintf("%s", FormatLoginCommand(r)),
 			Detail:  "Invalid API key format: " + err.Error(),
 		}, false
 	}
@@ -167,7 +188,7 @@ func APIKeyFromRequest(ctx context.Context, db database.Store, sessionTokenFunc 
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, codersdk.Response{
-				Message: SignedOutErrorMessage,
+				Message: fmt.Sprintf("%s", FormatLoginCommand(r)),
 				Detail:  "API key is invalid.",
 			}, false
 		}
@@ -182,7 +203,7 @@ func APIKeyFromRequest(ctx context.Context, db database.Store, sessionTokenFunc 
 	hashedSecret := sha256.Sum256([]byte(keySecret))
 	if subtle.ConstantTimeCompare(key.HashedSecret, hashedSecret[:]) != 1 {
 		return nil, codersdk.Response{
-			Message: SignedOutErrorMessage,
+			Message: fmt.Sprintf("%s", FormatLoginCommand(r)),
 			Detail:  "API key secret is invalid.",
 		}, false
 	}
@@ -229,6 +250,7 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 
 	key, resp, ok := APIKeyFromRequest(ctx, cfg.DB, cfg.SessionTokenFunc, r)
 	if !ok {
+		resp.Message = fmt.Sprintf("%s\n%s", resp.Message, FormatLoginCommand(r))
 		return optionalWrite(http.StatusUnauthorized, resp)
 	}
 
@@ -247,7 +269,7 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 		})
 		if errors.Is(err, sql.ErrNoRows) {
 			return optionalWrite(http.StatusUnauthorized, codersdk.Response{
-				Message: SignedOutErrorMessage,
+				Message: fmt.Sprintf("%s", FormatLoginCommand(r)),
 				Detail:  "You must re-authenticate with the login provider.",
 			})
 		}
@@ -318,7 +340,7 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 	// in site/src/components/RequireAuth/RequireAuth.tsx as well.
 	if key.ExpiresAt.Before(now) {
 		return optionalWrite(http.StatusUnauthorized, codersdk.Response{
-			Message: SignedOutErrorMessage,
+			Message: fmt.Sprintf("%s", FormatLoginCommand(r)),
 			Detail:  fmt.Sprintf("API key expired at %q.", key.ExpiresAt.String()),
 		})
 	}

--- a/coderd/httpmw/apikey_test.go
+++ b/coderd/httpmw/apikey_test.go
@@ -40,6 +40,34 @@ func randomAPIKeyParts() (id string, secret string) {
 }
 
 func TestAPIKey(t *testing.T) {
+	t.Run("ErrorIncludesEnvironmentContext", func(t *testing.T) {
+		t.Parallel()
+		var (
+			db = dbmem.New()
+			r  = httptest.NewRequest("GET", "/", nil)
+			rw = httptest.NewRecorder()
+		)
+		r.Host = "test.coder.com"
+
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB:              db,
+			RedirectToLogin: false,
+		})(successHandler).ServeHTTP(rw, r)
+		res := rw.Result()
+		defer res.Body.Close()
+		require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+
+		var resp codersdk.Response
+		err := json.NewDecoder(res.Body).Decode(&resp)
+		require.NoError(t, err)
+
+		expectedURL := "https://" + r.Host
+		require.Contains(t, resp.Message, expectedURL)
+		logCommand := fmt.Sprintf("coder login %s", expectedURL)
+		require.Contains(t, resp.Message, logCommand)
+	})
+
+
 	t.Parallel()
 
 	// assertActorOk asserts all the properties of the user auth are ok.


### PR DESCRIPTION
## Summary
- Updated authentication error messages to display environment-specific context for better user experience
- Error messages now include custom login commands with the correct URL and binary path based on environment variables
- Added test case to verify the environment context is included in error messages

## Test plan
- Manually verify that when authentication fails, error messages include the correct URL and binary path
- Added unit test to verify the URL and command are included in the error message
- Test with and without environment variables set to ensure correct behavior in all scenarios

Fixes #44 

🤖 Generated with [Claude Code](https://claude.ai/code)