### PR TITLE
Display environment context in CLI error messages

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -72,7 +72,15 @@ const (
 	varDisableDirect           = "disable-direct-connections"
 	varDisableNetworkTelemetry = "disable-network-telemetry"
 
-	notLoggedInMessage = "You are not logged in. Try logging in using 'coder login <url>'."
+	notLoggedInMessage = "You are not logged in. Try logging in using 'coder login %s'."
+	
+	getLoginCommand = func() string {
+		url := os.Getenv(envURL)
+		if url == "" {
+			return "'coder login <url>'"
+		}
+		return fmt.Sprintf("'coder login %s'", url)
+	}
 
 	envNoVersionCheck   = "CODER_NO_VERSION_WARNING"
 	envNoFeatureWarning = "CODER_NO_FEATURE_WARNING"
@@ -534,7 +542,7 @@ func (r *RootCmd) InitClient(client *codersdk.Client) serpent.MiddlewareFunc {
 				rawURL, err := conf.URL().Read()
 				// If the configuration files are absent, the user is logged out
 				if os.IsNotExist(err) {
-					return xerrors.New(notLoggedInMessage)
+					return xerrors.New(fmt.Sprintf(notLoggedInMessage, getLoginCommand()))
 				}
 				if err != nil {
 					return err

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -77,6 +77,31 @@ func TestCommandHelp(t *testing.T) {
 
 func TestRoot(t *testing.T) {
 	t.Parallel()
+
+	t.Run("LoginMessage_WithoutURL", func(t *testing.T) {
+		t.Parallel()
+
+		// Make sure CODER_URL is not set
+		os.Unsetenv("CODER_URL")
+
+		inv, _ := clitest.New(t, "list")
+		err := inv.Run()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Try logging in using 'coder login <url>'")
+	})
+
+	t.Run("LoginMessage_WithURL", func(t *testing.T) {
+		t.Parallel()
+
+		const testURL = "https://test.coder.com"
+		t.Setenv("CODER_URL", testURL)
+
+		inv, _ := clitest.New(t, "list")
+		err := inv.Run()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Try logging in using 'coder login "+testURL+"'")
+	})
+
 	t.Run("MissingRootCommand", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"net/url"
 	"strings"
 	"time"
@@ -76,9 +77,22 @@ func (c *OAuth2Configs) IsZero() bool {
 }
 
 const (
+	// envURL is imported from cli/root.go
+	envURL = "CODER_URL"
+	
 	SignedOutErrorMessage = "You are signed out or your session has expired. Please sign in again to continue."
 	internalErrorMessage  = "An internal error occurred. Please try again or contact the system administrator."
 )
+
+// getLoginCommand returns a command string to login with coder CLI
+// It respects the CODER_URL environment variable if set
+func getLoginCommand() string {
+	url := os.Getenv(envURL)
+	if url == "" {
+		return "'coder login <url>'"
+	}
+	return fmt.Sprintf("'coder login %s'", url)
+}
 
 type ExtractAPIKeyConfig struct {
 	DB                          database.Store
@@ -150,7 +164,7 @@ func APIKeyFromRequest(ctx context.Context, db database.Store, sessionTokenFunc 
 	if token == "" {
 		return nil, codersdk.Response{
 			Message: SignedOutErrorMessage,
-			Detail:  fmt.Sprintf("Cookie %q or query parameter must be provided.", codersdk.SessionTokenCookie),
+			Detail:  fmt.Sprintf("Cookie %q or query parameter must be provided. Try logging in again with %s", codersdk.SessionTokenCookie, getLoginCommand()),
 		}, false
 	}
 
@@ -158,7 +172,7 @@ func APIKeyFromRequest(ctx context.Context, db database.Store, sessionTokenFunc 
 	if err != nil {
 		return nil, codersdk.Response{
 			Message: SignedOutErrorMessage,
-			Detail:  "Invalid API key format: " + err.Error(),
+			Detail:  "Invalid API key format: " + err.Error() + ". Try logging in again with " + getLoginCommand(),
 		}, false
 	}
 
@@ -168,7 +182,7 @@ func APIKeyFromRequest(ctx context.Context, db database.Store, sessionTokenFunc 
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, codersdk.Response{
 				Message: SignedOutErrorMessage,
-				Detail:  "API key is invalid.",
+				Detail:  "API key is invalid. Try logging in again with " + getLoginCommand(),
 			}, false
 		}
 
@@ -183,7 +197,7 @@ func APIKeyFromRequest(ctx context.Context, db database.Store, sessionTokenFunc 
 	if subtle.ConstantTimeCompare(key.HashedSecret, hashedSecret[:]) != 1 {
 		return nil, codersdk.Response{
 			Message: SignedOutErrorMessage,
-			Detail:  "API key secret is invalid.",
+			Detail:  "API key secret is invalid. Try logging in again with " + getLoginCommand(),
 		}, false
 	}
 
@@ -319,7 +333,7 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 	if key.ExpiresAt.Before(now) {
 		return optionalWrite(http.StatusUnauthorized, codersdk.Response{
 			Message: SignedOutErrorMessage,
-			Detail:  fmt.Sprintf("API key expired at %q.", key.ExpiresAt.String()),
+			Detail:  fmt.Sprintf("API key expired at %q. Try logging in again with %s", key.ExpiresAt.String(), getLoginCommand()),
 		})
 	}
 


### PR DESCRIPTION
## Summary
- Update error messages to show specific login command based on the CODER_URL environment variable
- Makes error messages more actionable and environment-aware
- Add tests for environment-aware error messages

## Test plan
- Run 'go test' to verify error message updates
- Test CLI with and without CODER_URL set
- Verify error messages contain correct login command

🤖 Generated with [Claude Code](https://claude.ai/code)