### PR TITLE
test: verify on-behalf-of badge with Coder GitHub App token

### DIFF
--- a/ON_BEHALF_OF_TEST.md
+++ b/ON_BEHALF_OF_TEST.md
@@ -1,0 +1,4 @@
+# Test: on-behalf-of badge verification
+
+This PR tests whether the Coder GitHub App token produces the 'on behalf of' badge.
+Created at 2026-03-20T03:07:51Z


### PR DESCRIPTION
This is a test PR to verify whether using the Coder GitHub App user-to-server token (`ghu_` prefix) produces the 'on behalf of' badge in the GitHub UI. Please close/delete after verification.